### PR TITLE
added compose file for containers and local vars

### DIFF
--- a/docker-compose-setup-db.yml
+++ b/docker-compose-setup-db.yml
@@ -1,0 +1,20 @@
+version: '3.4'
+services:
+  postgres:
+    image: postgres:10
+    volumes:
+      - ./mnt/postgres:/var/lib/postgresql/data/pgdata
+    env_file:
+      - local.env
+    ports:
+      - 5432:5432
+
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: always
+    depends_on:
+      - postgres
+    env_file:
+      - local.env
+    ports:
+      - 80:80

--- a/local.env
+++ b/local.env
@@ -1,0 +1,7 @@
+POSTGRES_USER=dev
+POSTGRES_PASSWORD=password
+POSTGRES_DB=dev
+PGDATA=/var/lib/postgresql/data/pgdata
+
+PGADMIN_DEFAULT_EMAIL=admin@admin.com
+PGADMIN_DEFAULT_PASSWORD=password


### PR DESCRIPTION
Initial dump for setting up a simple docker environment with a container for postgres and a container for pgadmin.

Local variables are included in local.env which the docker compose file reads in.

Things to do:

1. Create scripts to update the data whenever the containers are stopped and started again. For this, we could do a shell script that runs docker-compose and then python scripts to seed the data after.
2. Set up another database for streaming data
3. Confirm that the host for the postgres db will be "algo_trading_postgres_1" in order to connect with python. Perhaps we can change the name to suit better in the docker-compose.yml file.