### PR TITLE
updated the dag to accurately backfill redis data.

### DIFF
--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -3,6 +3,7 @@ from typing import List, Dict
 
 
 class ColumnController(Enum):
+    # DB stuff
     date = "date"
     open = "open"
     high = "high"
@@ -14,6 +15,11 @@ class ColumnController(Enum):
     ma_50 = "ma_50"
     ma_21 = "ma_21"
     ma_7 = "ma_7"
+
+    # Key Value stuff
+    last_cross_up = "last_cross_up"
+    last_cross_down = "last_cross_down"
+    last_status = "last_status"
 
     @classmethod
     def df_columns(cls) -> List[str]:
@@ -51,6 +57,13 @@ class ColumnController(Enum):
             cls.ma_21.value: 21,
             cls.ma_7.value: 7,
         }
+
+
+class StockStatusController(Enum):
+    buy = "BUY"
+    sell = "SELL"
+    wait = "WAIT"
+    hold = "HOLD"
 
 
 class DBTypeController(Enum):


### PR DESCRIPTION
peeps the `cross_up()` and `cross_down()` functions that have the logic to determine if there was a cross up or down. those functions are used in `backfill_redis()` and `update_redis()`. I would like to move `cross_up()` and `cross_down()` to `sma_cross_strat.py` as utility functions that get imported into the DAG.

i know the `ColumnController.last_cross_date.value` stuff can look a little confusing but just know that it references the enumeration found in `config/controllers.py` so that we don't have any hard coded strings in the dag. like we talked about, if we wanted to change the name of "last_cross_date", we would only have to change it in one spot and it will cascade through instead of having to change every hard coded value.