### PR TITLE
added backtesting infrastructure

### DIFF
--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -66,7 +66,8 @@ class StockStatusController(Enum):
     hold = "HOLD"
 
 
-class DBTypeController(Enum):
+class DBHandlerController(Enum):
+    fake = "fake"
     postgres = "postgres"
 
 
@@ -75,4 +76,5 @@ class DataHandlerController(Enum):
 
 
 class KeyValueController(Enum):
+    fake = "fake"
     redis = "redis"

--- a/algo_trading/constants.py
+++ b/algo_trading/constants.py
@@ -1,1 +1,36 @@
+from os import getenv
+from dotenv import load_dotenv
+
+load_dotenv("../local.env")
+
+# Loading in DB info
+DB_HOST = getenv("POSTGRES_HOST")
+DB_PORT = getenv("POSTGRES_PORT")
+DB_NAME = getenv("POSTGRES_DB")
+DB_USER = getenv("POSTGRES_USER")
+DB_PASSWORD = getenv("POSTGRES_PASSWORD")
+
+# Loading in IN MEMORY info
+KV_HOST = getenv("REDIS_HOST")
+KV_PORT = getenv("REDIS_PORT")
+KV_DATABASE = getenv("REDIS_DB")
+KV_PASSWORD = getenv("REDIS_PASSWORD")
+
+
+# Building global vars for processing
+
+DB_INFO = {
+    "host": DB_HOST,
+    "db_name": DB_NAME,
+    "user": DB_USER,
+    "password": DB_PASSWORD,
+    "port": DB_PORT,
+}
+KV_INFO = {
+    "host": KV_HOST,
+    "port": KV_PORT,
+    "db": KV_DATABASE,
+    "password": KV_PASSWORD,
+}
+
 DATE_FORMAT = "%Y-%m-%d"

--- a/algo_trading/repositories/data_repository.py
+++ b/algo_trading/repositories/data_repository.py
@@ -34,6 +34,15 @@ class YahooFinanceDataRepository(AbstractDataRepository):
         end_date: str,
         interval: str = "1d",
     ) -> None:
+        """Data Repository that hits the Yahoo Finance API endpoint
+        to get raw price data and return it as a pandas DF.
+
+        Args:
+            ticker (str): Ticker to fetch data.
+            start_date (str): Get data starting here.
+            end_date (str): Get data up until this point (not including).
+            interval (str, optional): Interval of datapoints. Defaults to "1d".
+        """
         self.ticker = ticker
         self.start_date = start_date
         self.end_date = end_date
@@ -69,14 +78,22 @@ class YahooFinanceDataRepository(AbstractDataRepository):
 
 
 class DataRepository:
-    data_handlers = {
-        "yahoo_finance": YahooFinanceDataRepository,
+    _data_handlers = {
+        DataHandlerController.yahoo_finance: YahooFinanceDataRepository,
     }
 
     def __init__(self, data_info: Dict, data_handler: DataHandlerController) -> None:
+        """A wrapper class to provide a consistent interface to the
+        different DataRepository types found in the _data_handlers class
+        attribute.
+
+        Args:
+            data_info (Dict): Info to splat into a DataRepository instance.
+            data_handler (DataHandlerController): Type of handler to use.
+        """
         self.data_info = data_info
         self.data_handler = data_handler
 
     @property
     def handler(self) -> AbstractDataRepository:
-        return DataRepository.data_handlers[self.data_handler](**self.data_info)
+        return DataRepository._data_handlers[self.data_handler](**self.data_info)

--- a/algo_trading/repositories/db_repository.py
+++ b/algo_trading/repositories/db_repository.py
@@ -1,16 +1,16 @@
-from typing import Dict, List
-from abc import ABC, abstractproperty
+from typing import Dict, List, Optional, Union
+from abc import ABC, abstractmethod, abstractproperty
 
 
 import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy.engine.base import Engine
 
-from algo_trading.config.controllers import ColumnController, DBTypeController
+from algo_trading.config.controllers import ColumnController, DBHandlerController
 from algo_trading.utils.utils import dt_to_str
 
 
-class AbstractDBRepository(ABC):
+class AbstractQuery(ABC):
     @abstractproperty
     def sql_alchemy_conn_str(self) -> str:
         pass
@@ -24,6 +24,14 @@ class AbstractDBRepository(ABC):
         pass
 
     @abstractproperty
+    def get_since_date(self) -> str:
+        pass
+
+    @abstractproperty
+    def get_all(self) -> str:
+        pass
+
+    @abstractproperty
     def create_table(self) -> str:
         pass
 
@@ -32,7 +40,7 @@ class AbstractDBRepository(ABC):
         pass
 
 
-class PostgresRepository(AbstractDBRepository):
+class PostgresQuery(AbstractQuery):
     def __init__(
         self,
         user: str,
@@ -60,6 +68,14 @@ class PostgresRepository(AbstractDBRepository):
         return "SELECT * FROM %s ORDER BY DATE DESC LIMIT %s"
 
     @property
+    def get_since_date(self) -> str:
+        return "SELECT * FROM %s WHERE DATE >= '%s'"
+
+    @property
+    def get_all(self) -> str:
+        return "SELECT * FROM %s ORDER BY DATE DESC"
+
+    @property
     def create_table(self) -> str:
         return "CREATE TABLE IF NOT EXISTS %s (%s)"
 
@@ -68,33 +84,84 @@ class PostgresRepository(AbstractDBRepository):
         return "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'public'"
 
 
-class DBRepository:
+class AbstractDBRepository(ABC):
+    """Abstract repository to define common methods that
+    interact with a DB.
 
-    db_types = {
-        "postgres": PostgresRepository,
-    }
+    Args:
+        ABC ([type]): Abstract Base Class
+    """
 
-    def __init__(
-        self,
-        ticker_list: List,
-        db_info: Dict,
-        db_type: DBTypeController,
-    ) -> None:
+    @abstractmethod
+    def get_days_back(self, ticker: str, days_back: int) -> pd.DataFrame:
+        pass
 
-        self.ticker_list = ticker_list
+    @abstractmethod
+    def get_since_date(self, ticker: str, date: str) -> pd.DataFrame:
+        pass
+
+    @abstractmethod
+    def get_all(self, ticker: str) -> pd.DataFrame:
+        pass
+
+
+class FakeDBRepository(AbstractDBRepository):
+    def __init__(self, data: pd.DataFrame) -> None:
+        """Fake DB repo that accepts data as a DF to act as
+        the table in the live price DB.
+
+        We add the idx_iterator because we assume that you
+        are using this for a test and want to iterate through
+        the DF to test strategies.
+
+        Args:
+            data (pd.DataFrame): Data to 'query' from.
+        """
+        self.data = data
+
+        self.idx_iterator = 0
+
+    def get_days_back(self, ticker: str, days_back: int) -> pd.DataFrame:
+        if (self.idx_iterator - days_back) < 0:
+            start_idx = 0
+        else:
+            start_idx = self.idx_iterator - days_back
+        data = self.data.iloc[start_idx : (self.idx_iterator)]
+        self.idx_iterator += 1
+        return data
+
+    def get_since_date(self, ticker: str, date: str) -> pd.DataFrame:
+        pass
+
+    def get_all(self, ticker: str) -> pd.DataFrame:
+        return self.data
+
+
+class PostgresRepository(AbstractDBRepository):
+    def __init__(self, db_info: Dict) -> None:
+        """DB Repository that taps into a Postgres instance.
+        There are a few added methods to the raw AbstractDBRepository
+        to handle some business scenarios.
+
+        Args:
+            db_info (Dict): DB connection information.
+        """
         self.db_info = db_info
-        self.db_type = db_type
 
     @property
-    def db_repo(self) -> AbstractDBRepository:
-        return DBRepository.db_types[self.db_type](**self.db_info)
+    def queries(self) -> AbstractQuery:
+        try:
+            return self._queries
+        except AttributeError:
+            self._queries = PostgresQuery(**self.db_info)
+        return self._queries
 
     @property
     def db_engine(self) -> Engine:
         try:
             return self._db_engine
         except AttributeError:
-            self._db_engine = sa.create_engine(self.db_repo.sql_alchemy_conn_str)
+            self._db_engine = sa.create_engine(self.queries.sql_alchemy_conn_str)
             return self._db_engine
 
     def _create_table(self, ticker: str) -> None:
@@ -102,18 +169,18 @@ class DBRepository:
         col_str = ", ".join(
             [f"{k} {v}" for k, v in ColumnController.db_columns().items()]
         )
-        query = self.db_repo.create_table % (ticker, col_str)
+        query = self.queries.create_table % (ticker, col_str)
         with self.db_engine.connect() as conn:
             conn.execute(query)
 
-    def _get_new_tickers(self) -> List[str]:
+    def _get_new_tickers(self, tickers: List[str]) -> List[str]:
         with self.db_engine.connect() as conn:
-            res = conn.execute(self.db_repo.get_current_tickers)
+            res = conn.execute(self.queries.get_current_tickers)
             current_tickers = [item[0] for item in res.fetchall()]
-        return list(set(self.ticker_list) - set(current_tickers))
+        return list(set(tickers) - set(current_tickers))
 
-    def create_new_ticker_tables(self) -> List:
-        new_tickers = self._get_new_tickers()
+    def create_new_ticker_tables(self, tickers: List[str]) -> List:
+        new_tickers = self._get_new_tickers(tickers)
         print(f"Processing {len(new_tickers)} new ticker(s).")
         for ticker in new_tickers:
             self._create_table(ticker)
@@ -124,11 +191,44 @@ class DBRepository:
         df.to_sql(ticker, con=self.db_engine, if_exists="append", index=False)
 
     def get_most_recent_date(self, ticker: str) -> str:
-        query = self.db_repo.get_most_recent_date % (ticker,)
+        query = self.queries.get_most_recent_date % (ticker,)
         with self.db_engine.connect() as conn:
             res = conn.execute(query)
         return dt_to_str(res.fetchall()[0][0])
 
     def get_days_back(self, ticker: str, days_back: int) -> pd.DataFrame:
-        query = self.db_repo.get_days_back % (ticker, days_back)
+        query = self.queries.get_days_back % (ticker, days_back)
         return pd.read_sql(query, con=self.db_engine)
+
+    def get_since_date(self, ticker: str, date: str) -> pd.DataFrame:
+        query = self.queries.get_since_date % (ticker, date)
+        return pd.read_sql(query, con=self.db_engine)
+
+    def get_all(self, ticker: str) -> pd.DataFrame:
+        query = self.queries.get_all % (ticker,)
+        return pd.read_sql(query, con=self.db_engine)
+
+
+class DBRepository:
+    _db_handlers = {
+        DBHandlerController.fake: FakeDBRepository,
+        DBHandlerController.postgres: PostgresRepository,
+    }
+
+    def __init__(
+        self, db_info: Union[Dict, pd.DataFrame], db_handler: DBHandlerController
+    ) -> None:
+        """A wrapper class to provide a consistent interface to the
+        different DBRepository types found in the _db_handlers class
+        attribute.
+
+        Args:
+            db_info (Union[Dict, pd.DataFrame]): Info to instantiate the DB object.
+            db_handler (DBHandlerController): Type of DB repo to fetch.
+        """
+        self.db_info = db_info
+        self.db_handler = db_handler
+
+    @property
+    def handler(self) -> AbstractDBRepository:
+        return DBRepository._db_handlers[self.db_handler](self.db_info)

--- a/algo_trading/repositories/key_val_repository.py
+++ b/algo_trading/repositories/key_val_repository.py
@@ -20,17 +20,8 @@ from algo_trading.config.controllers import KeyValueController
 
 
 class AbstractKeyValueRepository(ABC):
-    @abstractproperty
-    def conn(self) -> Union[redis.Connection]:
-        """Connection to key val server.
-
-        Returns:
-            Union[redis.Connection]: Connection object types.
-        """
-        pass
-
     @abstractmethod
-    def set(self, key: str, value: Union[Dict[str, Any], str]) -> bool:
+    def set(self, key: str, value: Union[str, Dict]) -> bool:
         """Set a key and value. The value can be either string or
         dict. If a dict, we json.dumps the value so it is stored as
         a string and can be json.loads in the application.
@@ -70,24 +61,44 @@ class RedisRepository(AbstractKeyValueRepository):
             self._conn = redis.Redis(**self.redis_info)
             return self._conn
 
-    def set(self, key: str, value: Union[Dict[str, Any], str]) -> None:
+    def set(self, key: str, value: Union[str, Dict]) -> None:
         if type(value) == dict:
             value = json.dumps(value)
         self.conn.set(key, value)
 
-    def get(self, key: str) -> Any:
+    def get(self, key: str) -> Optional[str]:
         return self.conn.get(key)
 
 
+class FakeKeyValueRepository(AbstractKeyValueRepository):
+    def __init__(self, data: Dict) -> None:
+        self.data = data
+
+    def set(self, key: str, value: Union[str, Dict]):
+        self.data[key] = value
+
+    def get(self, key: str) -> Optional[str]:
+        return self.data[key]
+
+
 class KeyValueRepository:
-    kv_handlers = {
-        "redis": RedisRepository,
+    _kv_handlers = {
+        KeyValueController.fake: FakeKeyValueRepository,
+        KeyValueController.redis: RedisRepository,
     }
 
     def __init__(self, kv_info: Dict, kv_handler: KeyValueController) -> None:
+        """A wrapper class to provide a consistent interface to the
+        different KeyValueRepository types found in the _kv_handlers class
+        attribute.
+
+        Args:
+            kv_info (Dict): Info to connect to a KV store.
+            kv_handler (KeyValueController): Type of KV store to use.
+        """
         self.kv_info = kv_info
         self.kv_handler = kv_handler
 
     @property
     def handler(self) -> AbstractKeyValueRepository:
-        return KeyValueRepository.kv_handlers[self.kv_handler](self.kv_info)
+        return KeyValueRepository._kv_handlers[self.kv_handler](self.kv_info)

--- a/algo_trading/strategies/abstract_strategy.py
+++ b/algo_trading/strategies/abstract_strategy.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+from algo_trading.strategies.events import TradeEvent
+
+
+class AbstractStrategy(ABC):
+    @abstractmethod
+    def run(self) -> TradeEvent:
+        pass

--- a/algo_trading/strategies/events.py
+++ b/algo_trading/strategies/events.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+import datetime
+
+from algo_trading.config.controllers import StockStatusController
+
+
+class Event:
+    pass
+
+
+@dataclass
+class TradeEvent(Event):
+    date: datetime.date
+    ticker: str
+    signal: StockStatusController

--- a/back_testing/controllers.py
+++ b/back_testing/controllers.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class TestPeriodController(Enum):
+    one_mo = "1mo"
+    three_mo = "3mo"
+    six_mo = "6mo"
+    one_yr = "1yr"
+    two_yr = "2yr"
+    five_yr = "5yr"
+    ten_yr = "10yr"
+    max = "max"

--- a/back_testing/sma_cross_backtest.py
+++ b/back_testing/sma_cross_backtest.py
@@ -1,0 +1,226 @@
+from typing import Dict, Optional, Union
+import pandas as pd
+from pydantic import validate_arguments
+
+from algo_trading.strategies.sma_cross_strat import SMACross
+from algo_trading.repositories.db_repository import AbstractDBRepository, DBRepository
+from algo_trading.repositories.key_val_repository import KeyValueRepository
+from algo_trading.config.controllers import (
+    ColumnController,
+    DBHandlerController,
+    KeyValueController,
+    StockStatusController,
+)
+from algo_trading.utils.utils import str_to_dt
+from algo_trading.strategies.events import TradeEvent
+
+from dags.sma_cross_dag import update_redis
+
+from controllers import TestPeriodController
+
+
+class SMACrossBackTester:
+
+    _days_back = {
+        TestPeriodController.one_mo: 30,
+        TestPeriodController.three_mo: 90,
+        TestPeriodController.six_mo: 180,
+        TestPeriodController.one_yr: 365,
+        TestPeriodController.two_yr: 730,
+        TestPeriodController.five_yr: 1825,
+        TestPeriodController.ten_yr: 3650,
+        TestPeriodController.max: "max",
+    }
+
+    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    def __init__(
+        self,
+        ticker: str,
+        db_info: Dict,
+        db_handler: DBHandlerController,
+        period: Optional[TestPeriodController] = None,
+        start_date: Optional[str] = None,
+        capital: int = 10000,
+    ) -> None:
+        """Initializer for the SMA Back tester. Provide EITHER
+        a period OR a start_date, but not both.
+
+        Args:
+            ticker (str): Ticker to test
+            db_info (Dict): Live DB to query to get price history data
+            db_handler (DBHandlerController): Type of live DB.
+            period (Optional[TestPeriodController], optional): Period to test. Defaults to None.
+            start_date (Optional[str], optional): Start date to test. Defaults to None.
+            capital (int, optional): Starting cash. Defaults to 10000.
+
+        Raises:
+            ValueError: Error if both period and start_date are supplied.
+        """
+        self.ticker = ticker
+        self.db_info = db_info
+        self.db_handler = db_handler
+        self.period = period
+        self.start_date = start_date
+        self.capital = capital
+
+        if self.period and self.start_date:
+            raise ValueError("Please include either a period or a start date, not both")
+
+        self.fake_db_repo = None
+        self.fake_kv_repo = None
+
+    @property
+    def days_back(self) -> Union[int, str, None]:
+        """Returns the number of days to query back if a period
+        is supplied to the class.
+
+        Returns:
+            Union[int, str, None]: Returns None, integer, or 'max'
+        """
+        if self.period:
+            return SMACrossBackTester._days_back[self.period]
+        else:
+            return None
+
+    @property
+    def db_repo(self) -> AbstractDBRepository:
+        """Live prices DB to pull data from to test.
+
+        Returns:
+            AbstractDBRepository: DB Repo handler object.
+        """
+        try:
+            return self._db_repo
+        except AttributeError:
+            self._db_repo = DBRepository(self.db_info, self.db_handler).handler
+            return self._db_repo
+
+    @property
+    def price_data(self) -> pd.DataFrame:
+        """Pulling data from the real DB. This is why we needed db_info.
+        Caches this data for testing so we don't have to clog the
+        live DB.
+
+        Returns:
+            pd.DataFrame: Price DF to use for testing.
+        """
+        try:
+            return self._price_data
+        except AttributeError:
+            if self.period:
+                if self.period == TestPeriodController.max:
+                    data = self.db_repo.get_all(self.ticker)
+                else:
+                    data = self.db_repo.get_days_back(self.ticker, self.days_back)
+            elif self.start_date:
+                data = self.db_repo.get_since_date(self.ticker, self.start_date)
+            self._price_data = data.sort_values(
+                [ColumnController.date.value], ascending=True
+            ).iloc[1:]
+            return self._price_data
+
+    def _get_num_shares(self, cash: float, share_price: float) -> float:
+        """Simple calculation of num shares to buy.
+
+        Args:
+            cash (float): Current cash
+            share_price (float): Share price
+
+        Returns:
+            float: Num shares to purchase
+        """
+        return cash / share_price
+
+    def _get_new_capital(self, num_shares: float, share_price: float) -> float:
+        """Simple calculation of capitcal after selling.
+
+        Args:
+            num_shares (float): Num shares to sell
+            share_price (float): Share price
+
+        Returns:
+            float: Liquid capital
+        """
+        return num_shares * share_price
+
+    def _get_percent_change(
+        self, start_cap: float, end_cap: float, precision: int = 2
+    ) -> float:
+        """Generate percent change from starting and ending capital.
+
+        Args:
+            start_cap (float): Starting capital
+            end_cap (float): Ending capital
+            precision (int, optional): Decimal places. Defaults to 2.
+
+        Returns:
+            float: Percent change
+        """
+        return round(((end_cap - start_cap) / start_cap) * 100, precision)
+
+    def test(self) -> None:
+        """Runs the SMA strategy over the cached price data.
+        Instantiates a fake DBRepository and a fake KeyValueRepository
+        to 'query' from.
+
+        Calculates percent gain/loss after
+        """
+        fake_db_repo = DBRepository(self.price_data, DBHandlerController.fake)
+        fake_kv_repo = KeyValueRepository(
+            kv_info={
+                ColumnController.last_cross_up.value: None,
+                ColumnController.last_cross_down.value: None,
+                ColumnController.last_status.value: StockStatusController.wait.value,
+            },
+            kv_handler=KeyValueController.fake,
+        )
+
+        sma = SMACross(self.ticker, fake_db_repo, fake_kv_repo)
+        starting_cap = self.capital
+        num_shares = 0
+        state = "sell"
+        for idx, row in self.price_data.iterrows():
+            result: TradeEvent = sma.check_sma_cross()
+            if result.signal == StockStatusController.buy:
+                if state == "sell":
+                    num_shares = self._get_num_shares(
+                        self.capital, row[ColumnController.close.value]
+                    )
+                    print(
+                        f"Bought {num_shares} shares at price {row[ColumnController.close.value]} "
+                        + f"on {row[ColumnController.date.value]}."
+                    )
+                    state = "buy"
+            elif result.signal == StockStatusController.sell:
+                if state == "buy":
+                    self.capital = self._get_new_capital(
+                        num_shares, row[ColumnController.close.value]
+                    )
+                    print(
+                        f"Sold {num_shares} shares at price "
+                        + f"{row[ColumnController.close.value]} on "
+                        + f"{row[ColumnController.date.value]} for a new capital of {self.capital}."
+                    )
+                    num_shares = 0
+                    state = "sell"
+        if num_shares != 0:
+            self.capital = self._get_new_capital(
+                num_shares, self.price_data.iloc[-1][ColumnController.close.value]
+            )
+            print(
+                f"Sold {num_shares} shares at price "
+                + f"{self.price_data.iloc[-1][ColumnController.close.value]} "
+                + f"on {self.price_data.iloc[-1][ColumnController.date.value]} "
+                + f"for a new capital of {self.capital}."
+            )
+        percent_change = self._get_percent_change(starting_cap, self.capital)
+        print(f"Starting cap: {starting_cap}, final cap: {self.capital}.")
+        print(f"Change over {self.period.value} is {percent_change} %.")
+
+
+if __name__ == "__main__":
+    from algo_trading.constants import DB_INFO
+
+    ticker = "aapl"
+    tester = SMACrossBackTester(ticker, DB_INFO, "postgres", "max", capital=1000)
+    tester.test()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ multitasking==0.0.9
 numpy==1.20.3
 pandas==1.2.4
 psycopg2-binary==2.9.1
+pydantic=1.8.2
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2021.1


### PR DESCRIPTION
Added a lot of files to support a backtester for the `SMACross` strategy. I wanted to include as little DB calls as possible, and since the strategy requires making a call for each run, it made sense to create a couple of "fakes" that mock DB calls but keep everything in memory. This includes the price data and key/value stuff.

We might have to tweak the key/value stuff once we have the strategy actually flushed out.

I also created a `TradeEvent`, which is a simple data class (soon to be upgraded to `pydantic`) that we should use instead of just tuples as we originally planned. Also, we should implement some kind of interface for all strategies so that the main method to call is called something like `run()` in an effort to possibly build out a beefier backtester that can be more general instead of a tester for each strategy.