### PR TITLE
implement object storage with MinIO/S3

### DIFF
--- a/algo_trading/config/__init__.py
+++ b/algo_trading/config/__init__.py
@@ -16,6 +16,11 @@ KV_PORT = getenv("REDIS_PORT")
 KV_DATABASE = getenv("REDIS_DB")
 KV_PASSWORD = getenv("REDIS_PASSWORD")
 
+# Loading in OBJECT STORAGE info
+OBJ_STORE_ENDPOINT = getenv("MINIO_ENDPOINT")
+OBJ_STORE_REGION = getenv("MINIO_REGION")
+OBJ_STORE_ACCESS_KEY = getenv("MINIO_ROOT_USER")
+OBJ_STORE_SECRET_KEY = getenv("MINIO_ROOT_PASSWORD")
 
 # Building global vars for processing
 
@@ -31,6 +36,12 @@ KV_INFO = {
     "port": KV_PORT,
     "db": KV_DATABASE,
     "password": KV_PASSWORD,
+}
+OBJ_STORE_INFO = {
+    "endpoint_url": OBJ_STORE_ENDPOINT,
+    "aws_access_key_id": OBJ_STORE_ACCESS_KEY,
+    "aws_secret_access_key": OBJ_STORE_SECRET_KEY,
+    "region_name": OBJ_STORE_REGION,
 }
 
 DATE_FORMAT = "%Y-%m-%d"

--- a/algo_trading/config/config.yml
+++ b/algo_trading/config/config.yml
@@ -1,6 +1,7 @@
 db_repo: postgres
 data_repo: yahoo_finance
 kv_repo: redis
+obj_store_repo: minio
 ticker_list:
   - aapl
 #  - nio

--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -78,3 +78,8 @@ class DataHandlerController(Enum):
 class KeyValueController(Enum):
     fake = "fake"
     redis = "redis"
+
+
+class ObjStoreController(Enum):
+    minio = "minio"
+    s3 = "s3"

--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pydantic import BaseModel
 from typing import List, Dict
 
 
@@ -83,3 +84,12 @@ class KeyValueController(Enum):
 class ObjStoreController(Enum):
     minio = "minio"
     s3 = "s3"
+
+
+class Config(BaseModel):
+
+    ticker_list: List
+    db_repo: str
+    data_repo: str
+    kv_repo: str
+    obj_store_repo: str

--- a/algo_trading/repositories/obj_store_repository.py
+++ b/algo_trading/repositories/obj_store_repository.py
@@ -1,0 +1,235 @@
+from logging import Logger
+from typing import Dict, List
+import boto3
+from abc import ABC, abstractmethod, abstractproperty
+from pydantic import validate_arguments
+
+from algo_trading.config import OBJ_STORE_INFO
+from algo_trading.config.controllers import ObjStoreController
+from algo_trading.logger.controllers import LogConfig
+from algo_trading.logger.default_logger import child_logger
+
+
+class AbstractObjStore(ABC):
+    """Abstract repository to define common methods that
+    persist raw data in an object storage location before
+    loading into the DB. Currently, Amazon S3 and MinIO
+    are supported.
+
+    Args:
+        ABC ([type]): Abstract Base Class
+    """
+
+    @abstractproperty
+    def client(self) -> boto3.client:
+        """Client to interact with simple storage services.
+        Currently supports Amazon S3 and MinIO, both of which
+        use the boto3 Client.
+
+        The client is constructed given the kwargs in __init__.
+
+        Returns:
+            boto3.client: Object storage client.
+        """
+        pass
+
+    @abstractmethod
+    def create_bucket(self, bucket: str) -> Dict:
+        """Creates bucket.
+
+        Args:
+            bucket (str): Bucket name to create.
+
+        Returns:
+            Dict: Response.
+        """
+        pass
+
+    @abstractmethod
+    def delete_bucket(self, bucket: str) -> Dict:
+        """Deletes bucket.
+
+        Args:
+            bucket (str): Bucket to delete.
+
+        Returns:
+            Dict: Response.
+        """
+
+    @abstractmethod
+    def delete_objects(self, bucket: str, objects: List[Dict]) -> Dict:
+        """Deletes objects in a bucket.
+
+        Args:
+            bucket (str): Bucket name.
+            objects (List[Dict]): List of objects to delete.
+
+        Returns:
+            Dict: Response.
+        """
+        pass
+
+    @abstractmethod
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        """Downloads a file from a bucket to local.
+
+        Args:
+            bucket (str): Bucket name.
+            key (str): File name in bucket.
+            filename (str): Local file name to store file.
+        """
+        pass
+
+    @abstractmethod
+    def list_buckets(self) -> Dict:
+        """Lists all buckets.
+
+        Returns:
+            Dict: Response.
+        """
+        pass
+
+    @abstractmethod
+    def list_objects(self, bucket: str) -> Dict:
+        """List objects in a bucket.
+
+        Args:
+            bucket (str): Bucket name.
+
+        Returns:
+            Dict: Response object.
+        """
+        pass
+
+    @abstractmethod
+    def upload_file(self, filename: str, bucket: str, key: str) -> None:
+        """Uploads a file from local to a bucket.
+
+        Args:
+            filename (str): Local file to upload.
+            bucket (str): Bucket name to upload to.
+            key (str): Key name to save the file.
+        """
+        pass
+
+
+class S3Repository(AbstractObjStore):
+    def __init__(
+        self,
+        aws_access_key_id: str,
+        aws_secret_access_key: str,
+        endpoint_url: str,
+        region_name: str,
+        log_info: LogConfig,
+    ) -> None:
+        """Object storage repository for S3 leveraging the boto3 client.
+        For local storage with MinIO, you can set endpoint_url to
+        http://localhost:9000.
+
+        Docs on MinIO and boto3:
+        https://docs.min.io/docs/how-to-use-aws-sdk-for-python-with-minio-server.html
+
+        Docs for all boto3 methods can be found here:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+
+        Args:
+            aws_access_key_id (str): AWS Access Key
+            aws_secret_access_key (str): AWS Secret Key
+            endpoint_url (str): AWS endpoint
+            region_name (str): AWS region
+            log_info (LogConfig): Logger config
+        """
+
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.endpoint_url = endpoint_url
+        self.region_name = region_name
+        self.log_info = log_info
+
+    @property
+    def log(self) -> Logger:
+        try:
+            return self._log
+        except AttributeError:
+            self._log = child_logger(self.log_info.log_name, self.__class__.__name__)
+            return self._log
+
+    @property
+    def client(self) -> boto3.client:
+        try:
+            return self._client
+        except AttributeError:
+            self._client = boto3.client(
+                "s3",
+                endpoint_url=self.endpoint_url,
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                region_name=self.region_name,
+            )
+            return self._client
+
+    def create_bucket(self, bucket: str) -> Dict:
+        self.client.create_bucket(Bucket=bucket)
+
+    def delete_bucket(self, bucket: str) -> Dict:
+        self.client.delete_bucket(Bucket=bucket)
+
+    def delete_objects(self, bucket: str, objects: List) -> Dict:
+        del_objects = [{"Key": obj} for obj in objects]
+        self.client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": del_objects},
+        )
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        return self.client.download_file(
+            Bucket=bucket,
+            Key=key,
+            Filename=filename,
+        )
+
+    def list_buckets(self) -> Dict:
+        return self.client.list_buckets()
+
+    def list_objects(self, bucket: str) -> Dict:
+        return self.client.list_objects_v2(Bucket=bucket)
+
+    def upload_file(self, filename: str, bucket: str, key: str) -> None:
+        return self.client.upload_file(
+            Filename=filename,
+            Bucket=bucket,
+            Key=key,
+        )
+
+
+class ObjStoreRepository:
+    _obj_handlers = {
+        ObjStoreController.minio: S3Repository,
+        ObjStoreController.s3: S3Repository,
+    }
+
+    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    def __init__(
+        self,
+        obj_store_info: Dict,
+        obj_handler: ObjStoreController,
+        log_info: LogConfig,
+    ) -> None:
+        """A wrapper class to provide a consistent interface to the
+        different ObjStore types found in the _obj_handlers class
+        attribute.
+
+        Args:
+            obj_store_info (Dict): Info to connect to the object store.
+            obj_handler (ObjStoreController): Type of object store to fetch.
+        """
+        self.obj_store_info = obj_store_info
+        self.obj_handler = obj_handler
+        self.log_info = log_info
+
+    @property
+    def handler(self) -> AbstractObjStore:
+        return ObjStoreRepository._obj_handlers[self.obj_handler](
+            log_info=self.log_info,
+            **self.obj_store_info,
+        )

--- a/algo_trading/repositories/obj_store_repository.py
+++ b/algo_trading/repositories/obj_store_repository.py
@@ -57,7 +57,7 @@ class AbstractObjStore(ABC):
         """
 
     @abstractmethod
-    def delete_objects(self, bucket: str, objects: List[Dict]) -> Dict:
+    def delete_objects(self, bucket: str, objects: List) -> Dict:
         """Deletes objects in a bucket.
 
         Args:
@@ -98,6 +98,19 @@ class AbstractObjStore(ABC):
 
         Returns:
             Dict: Response object.
+        """
+        pass
+
+    @abstractmethod
+    def put_object(self, file_body: str, bucket: str, key: str) -> None:
+        """Uploads a file object from memory (StringIO.getvalue() string) to a
+        bucket. Typical use case is to upload a pandas DF directly to object
+        storage instead of saving it to disk and then uploading.
+
+        Args:
+            file_body (str): StringIO.getvalue() string
+            bucket (str): Bucket destination
+            key (str): File destination within bucket
         """
         pass
 
@@ -193,6 +206,13 @@ class S3Repository(AbstractObjStore):
 
     def list_objects(self, bucket: str) -> Dict:
         return self.client.list_objects_v2(Bucket=bucket)
+
+    def put_object(self, file_body: str, bucket: str, key: str) -> None:
+        return self.client.put_object(
+            Body=file_body,
+            Bucket=bucket,
+            Key=key,
+        )
 
     def upload_file(self, filename: str, bucket: str, key: str) -> None:
         return self.client.upload_file(

--- a/algo_trading/repositories/tests/obj_store_repository_test.py
+++ b/algo_trading/repositories/tests/obj_store_repository_test.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+import os
+
+import yaml as yl
+import pandas as pd
+from algo_trading.logger.controllers import LogConfig, LogLevelController
+
+from algo_trading.repositories.obj_store_repository import ObjStoreRepository
+from algo_trading.utils.utils import dt_to_str
+
+"""
+Assuming we are running the test from our local machine, we set the
+endpoint to localhost:9000. If we are to Dockerize the app, we need to change it
+accordingly to the network location.
+"""
+
+# Loading in and parsing config
+# NEED TO CHANGE THIS TO ENVIRONMENT VARIABLES INSTEAD
+config_path = os.path.join(
+    "/Users/ryanlattanzi/Desktop/projects/trading_app/algo_trading",
+    "config/config.yml",
+)
+config = yl.safe_load(open(config_path, "r"))
+obj_store_handler = config["obj_store_repo"]
+
+obj_store_info = {
+    "endpoint_url": "http://localhost:9000",
+    "aws_access_key_id": "admin",
+    "aws_secret_access_key": "password",
+    "region_name": "us-east-1",
+}
+
+log_info = LogConfig(
+    log_name="obj_store_repository_test",
+    file_name=os.path.join(
+        "logs", f"obj_store_repository_test_{dt_to_str(datetime.today())}.log"
+    ),
+    log_level=LogLevelController.info,
+)
+
+data = pd.read_csv("sample_data.csv")
+
+obj_store_repo = ObjStoreRepository(
+    obj_store_info=obj_store_info,
+    obj_handler=obj_store_handler,
+    log_info=log_info,
+)
+
+obj_store_handler = obj_store_repo.handler
+
+
+def test_bucket_integration():
+    bucket_name = "test-bucket"
+    obj_store_handler.create_bucket("test-bucket")
+    buckets = obj_store_handler.list_buckets()
+    # print(buckets["Buckets"])
+
+    assert bucket_name in [bucket["Name"] for bucket in buckets["Buckets"]]
+    obj_store_handler.delete_bucket(bucket_name)
+
+    buckets = obj_store_handler.list_buckets()
+    assert bucket_name not in [bucket["Name"] for bucket in buckets["Buckets"]]
+
+
+if __name__ == "__main__":
+    test_bucket_integration()

--- a/algo_trading/utils/utils.py
+++ b/algo_trading/utils/utils.py
@@ -1,10 +1,15 @@
 from typing import List
 from datetime import datetime
 import pandas as pd
+import yaml
 
-from algo_trading.config.controllers import ColumnController
+from algo_trading.config.controllers import ColumnController, Config
+from algo_trading.config import DATE_FORMAT
 
-DATE_FORMAT = "%Y-%m-%d"
+
+def parse_config(config_path: str) -> Config:
+    config = yaml.safe_load(open(config_path, "r"))
+    return Config(**config)
 
 
 def clean_df(df: pd.DataFrame) -> pd.DataFrame:

--- a/dags/data_pull_dag.py
+++ b/dags/data_pull_dag.py
@@ -10,9 +10,10 @@ from algo_trading.logger.controllers import LogConfig, LogLevelController
 from algo_trading.utils.calculations import Calculator
 from algo_trading.repositories.data_repository import DataRepository
 from algo_trading.repositories.db_repository import DBRepository
+from algo_trading.repositories.obj_store_repository import ObjStoreRepository
 from algo_trading.config.controllers import ColumnController, DBHandlerController
 from algo_trading.utils.utils import clean_df, str_to_dt, dt_to_str
-from algo_trading.config import DB_INFO, DATE_FORMAT
+from algo_trading.config import DB_INFO, DATE_FORMAT, OBJ_STORE_INFO
 
 LOG_INFO = LogConfig(
     log_name="data_pull_dag",

--- a/dags/data_pull_dag.py
+++ b/dags/data_pull_dag.py
@@ -1,4 +1,5 @@
 import os
+from io import StringIO
 from datetime import datetime, timedelta
 from typing import Dict, List
 
@@ -11,8 +12,12 @@ from algo_trading.utils.calculations import Calculator
 from algo_trading.repositories.data_repository import DataRepository
 from algo_trading.repositories.db_repository import DBRepository
 from algo_trading.repositories.obj_store_repository import ObjStoreRepository
-from algo_trading.config.controllers import ColumnController, DBHandlerController
-from algo_trading.utils.utils import clean_df, str_to_dt, dt_to_str
+from algo_trading.config.controllers import (
+    ColumnController,
+    DBHandlerController,
+    ObjStoreController,
+)
+from algo_trading.utils.utils import clean_df, str_to_dt, dt_to_str, parse_config
 from algo_trading.config import DB_INFO, DATE_FORMAT, OBJ_STORE_INFO
 
 LOG_INFO = LogConfig(
@@ -21,11 +26,40 @@ LOG_INFO = LogConfig(
     log_level=LogLevelController.info,
 )
 
-
 LOG = main_logger(LOG_INFO)
 
+OBJ_STORE_DATA_BUCKET = "algo-trading-price-data"
+OBJ_STORE_DATA_KEY = "{ticker}/{run_date}.csv"
 
-def create_new_tables(db_info: Dict, db_handler: str, tickers: List) -> List:
+OBJ_STORE_LOG_BUCKET = "algo-trading-logs"
+OBJ_STORE_LOG_KEY = "data_pull_dag/{run_date}.log"
+
+CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)).replace("dags", "algo_trading"),
+    "config/config.yml",
+)
+CONFIG = parse_config(CONFIG_PATH)
+
+DB_HANDLER = DBRepository(
+    DB_INFO,
+    DBHandlerController[CONFIG.db_repo],
+    LOG_INFO,
+).handler
+
+OBJ_STORE_HANDLER = ObjStoreRepository(
+    OBJ_STORE_INFO,
+    ObjStoreController[CONFIG.obj_store_repo],
+    LOG_INFO,
+).handler
+
+
+def create_bucket(bucket_name: str) -> None:
+    buckets = OBJ_STORE_HANDLER.list_buckets()
+    if bucket_name not in [bucket["Name"] for bucket in buckets["Buckets"]]:
+        OBJ_STORE_HANDLER.create_bucket(bucket_name)
+
+
+def create_new_tables(tickers: List) -> List:
     """
     Initializes the config DBInterface instance and creates new tables
     based off of new tickers that popped up in the configuration.
@@ -33,17 +67,13 @@ def create_new_tables(db_info: Dict, db_handler: str, tickers: List) -> List:
     Returns:
         List: List of new tickers
     """
-    db = DBRepository(
-        db_info,
-        DBHandlerController[db_handler],
-        LOG_INFO,
-    ).handler
-    new_tickers = db.create_new_ticker_tables(tickers)
+    new_tickers = DB_HANDLER.create_new_ticker_tables(tickers)
     return new_tickers
 
 
 def get_new_ticker_data(
-    data_handler: str, new_tickers: List
+    data_handler: str,
+    new_tickers: List,
 ) -> Dict[str, pd.DataFrame]:
     """
     Gets historical data for the list of new tickers found.
@@ -76,29 +106,35 @@ def get_new_ticker_data(
     return new_ticker_data
 
 
-def add_new_ticker_data(
-    db_info: Dict, db_handler: Dict, new_ticker_data: Dict[str, pd.DataFrame]
-) -> None:
+def persist_ticker_data(ticker_data: Dict[str, pd.DataFrame]) -> None:
     """
-    Slaps the historical data from pd.DataFrame into the DB.
-    For now, this is meant to run for new tickers, since it will
-    load the entire DF into the table.
+    Slaps the historical data from pd.DataFrame into the DB and Object
+    Store.
 
     Args:
-        new_ticker_data (Dict): New data to be loaded to the DB
+        ticker_data (Dict): Data to be loaded to the DB
     """
-    db = DBRepository(
-        db_info,
-        DBHandlerController[db_handler],
-        LOG_INFO,
-    ).handler
 
-    for ticker, df in new_ticker_data.items():
-        db.append_df_to_sql(ticker, df)
+    for ticker, df in ticker_data.items():
+        # Persisting data to object storage.
+        csv_buffer = StringIO()
+        df.to_csv(csv_buffer, index=False)
+        OBJ_STORE_HANDLER.put_object(
+            file_body=csv_buffer.getvalue(),
+            bucket=OBJ_STORE_DATA_BUCKET,
+            key=OBJ_STORE_DATA_KEY.format(
+                ticker=ticker, run_date=dt_to_str(datetime.today())
+            ),
+        )
+
+        # Saving data to the database.
+        DB_HANDLER.append_df_to_sql(ticker, df)
 
 
 def get_existing_ticker_data(
-    db_info: Dict, db_handler: str, data_handler: str, tickers: List, new_tickers: List
+    data_handler: str,
+    tickers: List,
+    new_tickers: List,
 ) -> Dict:
     """
     Gets data for the list of existing tickers. The DF date will
@@ -116,14 +152,9 @@ def get_existing_ticker_data(
         Dict: Existing data with key: ticker, val: pd.DataFrame
     """
     updated_ticker_data = dict()
-    db = DBRepository(
-        db_info,
-        DBHandlerController[db_handler],
-        LOG_INFO,
-    ).handler
 
     for ticker in [t for t in tickers if t not in new_tickers]:
-        last_date_entry_str = db.get_most_recent_date(ticker)
+        last_date_entry_str = DB_HANDLER.get_most_recent_date(ticker)
         last_date_entry = str_to_dt(last_date_entry_str)
 
         query_date = last_date_entry + timedelta(days=1)
@@ -169,7 +200,7 @@ def get_existing_ticker_data(
         )
 
         # Getting rows 199 days back from the earliest row of the DF
-        hist_df = db.get_days_back(ticker, 199)
+        hist_df = DB_HANDLER.get_days_back(ticker, 199)
         full_df = pd.concat([hist_df, stock_df], axis=0).reset_index(drop=True)
         full_df[ColumnController.date.value] = pd.to_datetime(
             full_df[ColumnController.date.value]
@@ -183,45 +214,32 @@ def get_existing_ticker_data(
     return updated_ticker_data
 
 
-def add_existing_ticker_data(
-    db_info: Dict, db_handler: Dict, existing_ticker_data: Dict
-) -> None:
-    """
-    Append updated ticker data to existing tables in the DB.
-
-    Args:
-        existing_ticker_data (Dict): Data to be loaded to the DB
-    """
-    db = DBRepository(
-        db_info,
-        DBHandlerController[db_handler],
-        LOG_INFO,
-    ).handler
-
-    for ticker, df in existing_ticker_data.items():
-        db.append_df_to_sql(ticker, df)
-
-    LOG.info(f"FINISHED ADDING DATA ON {dt_to_str(datetime.today())}.\n")
+def persist_log() -> None:
+    OBJ_STORE_HANDLER.upload_file(
+        LOG_INFO.file_name,
+        OBJ_STORE_LOG_BUCKET,
+        OBJ_STORE_LOG_KEY.format(run_date=dt_to_str(datetime.today())),
+    )
 
 
 if __name__ == "__main__":
 
-    # Loading in and parsing config
-    config_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)).replace("dags", "algo_trading"),
-        "config/config.yml",
+    create_bucket(OBJ_STORE_DATA_BUCKET)
+    create_bucket(OBJ_STORE_LOG_BUCKET)
+
+    new_tickers = create_new_tables(CONFIG.ticker_list)
+    new_ticker_data = get_new_ticker_data(
+        CONFIG.data_repo,
+        new_tickers,
     )
-    config = yl.safe_load(open(config_path, "r"))
-    tickers = config["ticker_list"]
-    db_handler = config["db_repo"]
-    data_handler = config["data_repo"]
-    kv_handler = config["kv_repo"]
-
-    new_tickers = create_new_tables(DB_INFO, db_handler, tickers)
-
-    new_ticker_data = get_new_ticker_data(data_handler, new_tickers)
-    add_new_ticker_data(DB_INFO, db_handler, new_ticker_data)
+    persist_ticker_data(new_ticker_data)
     existing_ticker_data = get_existing_ticker_data(
-        DB_INFO, db_handler, data_handler, tickers, new_tickers
+        CONFIG.data_repo,
+        CONFIG.ticker_list,
+        new_tickers,
     )
-    add_existing_ticker_data(DB_INFO, db_handler, existing_ticker_data)
+    persist_ticker_data(existing_ticker_data)
+
+    LOG.info(f"FINISHED ADDING DATA ON {dt_to_str(datetime.today())}.\n")
+
+    persist_log()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '3.4'
 
 volumes:
-  postgres_data:
+  postgres_data: null
+  object_storage: null
 
 networks:
-  algo_trading_network:
+  algo_trading_network: null
 
 services:
   postgres:
@@ -37,3 +38,27 @@ services:
     command: redis-server --requirepass redispassword
     networks:
       - algo_trading_network
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2021-12-10T23-03-39Z
+    volumes:
+      - object_storage:/object_storage
+    ports:
+      - 9000:9000
+      - 9001:9001
+    env_file:
+      - .env
+    command: server /object_storage --console-address ":9001"
+    networks:
+      - algo_trading_network
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:9000/minio/health/live"
+        ]
+      interval: 30s
+      timeout: 20s
+      retries: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,15 @@
+black==21.12b0
+boto3==1.20.26
+botocore==1.23.26
+click==8.0.3
 greenlet==1.1.2
 importlib-metadata==4.8.2
+jmespath==0.10.0
+mypy-extensions==0.4.3
 numpy==1.21.4
 pandas==1.2.4
+pathspec==0.9.0
+platformdirs==2.4.0
 psycopg2-binary==2.9.1
 pydantic==1.8.2
 python-dateutil==2.8.1
@@ -9,8 +17,11 @@ python-dotenv==0.19.0
 pytz==2021.3
 PyYAML==5.4.1
 redis==3.5.3
+s3transfer==0.5.0
 six==1.16.0
 SQLAlchemy==1.4.22
+tomli==1.2.3
+typed-ast==1.5.1
 typing-extensions==4.0.1
 urllib3==1.26.6
 zipp==3.6.0


### PR DESCRIPTION
Got the `data_pull_dag` working to save logs and data to the buckets in MinIO. MinIO can easily be swapped for actual S3 by switching out the `MINIO_ENDPOINT` in your `.env` file.

We need to think of a better way to persist price data to the bucket. Right now, it's CSVs, so if it runs once per day, it'll save a CSV with just one line...perhaps we think of doing an append-only log that we just keep adding to or something? Maybe we don't need it at all and just depend on the logs?