### PR TITLE
Controlling the SMACrossInfo as a pydantic object instead of free-form dict

### DIFF
--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -17,11 +17,6 @@ class ColumnController(Enum):
     ma_21 = "ma_21"
     ma_7 = "ma_7"
 
-    # Key Value stuff
-    last_cross_up = "last_cross_up"
-    last_cross_down = "last_cross_down"
-    last_status = "last_status"
-
     @classmethod
     def df_columns(cls) -> List[str]:
         return [
@@ -60,37 +55,37 @@ class ColumnController(Enum):
         }
 
 
-class StockStatusController(Enum):
+class StockStatusController(str, Enum):
     buy = "BUY"
     sell = "SELL"
     wait = "WAIT"
     hold = "HOLD"
 
 
-class DBHandlerController(Enum):
+class DBHandlerController(str, Enum):
     fake = "fake"
     postgres = "postgres"
 
 
-class DataHandlerController(Enum):
+class DataHandlerController(str, Enum):
     yahoo_finance = "yahoo_finance"
 
 
-class KeyValueController(Enum):
+class KeyValueController(str, Enum):
     fake = "fake"
     redis = "redis"
 
 
-class ObjStoreController(Enum):
+class ObjStoreController(str, Enum):
     minio = "minio"
     s3 = "s3"
 
 
-class PubSubController(Enum):
+class PubSubController(str, Enum):
     redis = "redis"
 
 
-class TestPeriodController(Enum):
+class TestPeriodController(str, Enum):
     one_mo = "1mo"
     three_mo = "3mo"
     six_mo = "6mo"
@@ -108,3 +103,10 @@ class Config(BaseModel):
     data_repo: str
     kv_repo: str
     obj_store_repo: str
+
+
+class SMACrossInfo(BaseModel):
+
+    last_cross_up: str = "1900-01-01"
+    last_cross_down: str = "1900-01-02"
+    last_status: StockStatusController = StockStatusController.sell

--- a/algo_trading/repositories/db_repository.py
+++ b/algo_trading/repositories/db_repository.py
@@ -155,6 +155,8 @@ class AbstractDBRepository(ABC):
 
 
 class FakeDBRepository(AbstractDBRepository):
+    idx_iterator = 0
+
     def __init__(self, data: pd.DataFrame, log_info: LogConfig) -> None:
         """Fake DB repo that accepts data as a DF to act as
         the table in the live price DB. The DF is in ASCENDING
@@ -170,8 +172,6 @@ class FakeDBRepository(AbstractDBRepository):
         self.data = data
         self.log_info = log_info
 
-        self.idx_iterator = 0
-
     def create_new_ticker_tables(self, tickers: List[str]) -> List:
         pass
 
@@ -182,7 +182,7 @@ class FakeDBRepository(AbstractDBRepository):
             start_idx = self.idx_iterator - days_back
 
         data = self.data.iloc[start_idx : (self.idx_iterator)]
-        self.idx_iterator += 1
+        FakeDBRepository.idx_iterator += 1
         return data
 
     def get_since_date(self, ticker: str, date: str) -> pd.DataFrame:

--- a/algo_trading/strategies/abstract_strategy.py
+++ b/algo_trading/strategies/abstract_strategy.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from algo_trading.strategies.events import TradeEvent
+from algo_trading.config.events import TradeEvent
 
 
 class AbstractStrategy(ABC):

--- a/algo_trading/strategies/sma_cross_strat.py
+++ b/algo_trading/strategies/sma_cross_strat.py
@@ -31,7 +31,9 @@ class SMACross(AbstractStrategy):
         try:
             return self._cross_info
         except AttributeError:
-            self._cross_info = SMACrossInfo(json.loads(self.cross_db.get(self.ticker)))
+            self._cross_info = SMACrossInfo(
+                **json.loads(self.cross_db.get(self.ticker))
+            )
             return self._cross_info
 
     @property
@@ -126,16 +128,16 @@ class SMACross(AbstractStrategy):
 
         if date:
             if last_cross_up > last_cross_down:
-                if last_status == StockStatusController.buy.value:
+                if last_status == StockStatusController.buy:
                     signal = StockStatusController.hold
-                elif last_status == StockStatusController.sell.value:
+                elif last_status == StockStatusController.sell:
                     signal = StockStatusController.buy
                     self._update_last_status(signal)
             else:
-                if last_status == StockStatusController.buy.value:
+                if last_status == StockStatusController.buy:
                     signal = StockStatusController.sell
                     self._update_last_status(signal)
-                elif last_status == StockStatusController.sell.value:
+                elif last_status == StockStatusController.sell:
                     signal = StockStatusController.wait
 
         else:

--- a/algo_trading/strategies/sma_cross_strat.py
+++ b/algo_trading/strategies/sma_cross_strat.py
@@ -3,8 +3,12 @@ import json
 import pandas as pd
 
 from algo_trading.strategies.abstract_strategy import AbstractStrategy
-from algo_trading.strategies.events import TradeEvent
-from algo_trading.config.controllers import ColumnController, StockStatusController
+from algo_trading.config.events import TradeEvent
+from algo_trading.config.controllers import (
+    ColumnController,
+    StockStatusController,
+    SMACrossInfo,
+)
 from algo_trading.repositories.db_repository import DBRepository
 from algo_trading.repositories.key_val_repository import KeyValueRepository
 from algo_trading.utils.utils import str_to_dt
@@ -23,8 +27,12 @@ class SMACross(AbstractStrategy):
         self.cross_db = cross_db.handler
 
     @property
-    def cross_info(self) -> Dict:
-        return json.loads(self.cross_db.get(self.ticker))
+    def cross_info(self) -> SMACrossInfo:
+        try:
+            return self._cross_info
+        except AttributeError:
+            self._cross_info = SMACrossInfo(json.loads(self.cross_db.get(self.ticker)))
+            return self._cross_info
 
     @property
     def sma_info(self) -> Dict:
@@ -100,8 +108,8 @@ class SMACross(AbstractStrategy):
             signal (StockStatusController): Enumeration signal.
         """
         current = self.cross_info
-        current[ColumnController.last_status.value] = signal.value
-        self.cross_db.set(self.ticker, current)
+        current.last_status = signal
+        self.cross_db.set(self.ticker, current.dict())
 
     def run(self) -> TradeEvent:
         """Runs the SMACross strategy logic based on the last cross up/down
@@ -110,11 +118,9 @@ class SMACross(AbstractStrategy):
         Returns:
             TradeEvent: Event
         """
-        last_cross_up = str_to_dt(self.cross_info[ColumnController.last_cross_up.value])
-        last_cross_down = str_to_dt(
-            self.cross_info[ColumnController.last_cross_down.value]
-        )
-        last_status = self.cross_info[ColumnController.last_status.value]
+        last_cross_up = str_to_dt(self.cross_info.last_cross_up)
+        last_cross_down = str_to_dt(self.cross_info.last_cross_down)
+        last_status = self.cross_info.last_status
 
         date = self.sma_info[ColumnController.date.value]
 

--- a/dags/sma_cross_dag.py
+++ b/dags/sma_cross_dag.py
@@ -121,7 +121,7 @@ def update_redis(tickers: List, new_tickers: List) -> None:
             LOG.error(f"No Redis data for ticker {ticker}...")
             continue
 
-        cross_info = SMACrossInfo(json.loads(cross_info))
+        cross_info = SMACrossInfo(**json.loads(cross_info))
 
         if SMACross.cross_up(data, 0):
             cross_info.last_cross_up = dt_to_str(

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,0 +1,11 @@
+
+#Orchestrating the DAGs
+cd ./dags
+python orchestrate.py
+
+#Backtesting
+cd ../back_testing
+python sma_cross_backtest.py
+
+#Change dir to original
+cd $current_dir


### PR DESCRIPTION
Changed the `sma_cross_info` thing that we use across SMA stuff into an object. That way, we know exactly what values are required for it, not just remembering that it includes last cross up, down, and last status.

Need to integration test this bad boy to make sure i didn't forget anything. See the new file `integration_test.sh`. It ensures everything runs smooth (orchestrator and back_tester).

One thing to note that's elegant is that the object comes with default values. So, in `sma_cross_dag.backfill_redis()`, i was able to delete a bunch of code that handled the edge cases of if we didn't see any crosses.

Finally, i added the `str` part in the enumerations so that they would be JSON serializable since the `SMACrossInfo` uses then enum `StockStatusController`.