### PR TITLE
Refactor sma utils for better logic separation

### DIFF
--- a/algo_trading/config/config.yml
+++ b/algo_trading/config/config.yml
@@ -5,7 +5,7 @@ obj_store_repo: minio
 ticker_list:
   - aapl
   - nio
-#  - fb
-#  - tsla
-#  - msft
-#  - amzn
+  - fb
+  - tsla
+  - msft
+  - amzn

--- a/algo_trading/strategies/sma_cross_strat.py
+++ b/algo_trading/strategies/sma_cross_strat.py
@@ -96,7 +96,6 @@ class SMACrossUtils:
                 >= data[ColumnController.ma_21.value].iloc[index - 1]
             )
             and (
-                # TODO: Should we change this to > ???
                 str_to_dt(cross_info.last_cross_down)
                 < str_to_dt(cross_info.last_cross_up)
             )

--- a/algo_trading/strategies/sma_cross_strat.py
+++ b/algo_trading/strategies/sma_cross_strat.py
@@ -11,7 +11,101 @@ from algo_trading.config.controllers import (
 )
 from algo_trading.repositories.db_repository import AbstractDBRepository
 from algo_trading.repositories.key_val_repository import AbstractKeyValueRepository
-from algo_trading.utils.utils import str_to_dt
+from algo_trading.utils.utils import dt_to_str, str_to_dt
+
+
+class SMACrossUtils:
+    @staticmethod
+    def check_cross_up(
+        data: pd.DataFrame,
+        index: int,
+        cross_info: SMACrossInfo,
+    ) -> SMACrossInfo:
+        """Checks to see if a cross up occured by looking at
+        the current date 7 and 21 day SMA and the previous date
+        7 and 21 day SMA. Finally, we only consider cross up
+        when the close price > 50 ay SMA otherwise the market
+        is considered bearish.
+
+        **NOTE**
+        We expect the dataframe to be in ASCENDING order by date.
+
+        Args:
+            data (pd.DataFrame): Data to parse SMA info.
+            index (int): Indicates current day. index + 1 = prev day.
+            cross_info (SMACrossInfo): Current cross info to analyze.
+
+        Returns:
+            SMACrossInfo: Updated (or not) SMACrossInfo object.
+        """
+        if (
+            (
+                data[ColumnController.ma_7.value].iloc[index]
+                >= data[ColumnController.ma_21.value].iloc[index]
+            )
+            and (
+                data[ColumnController.ma_7.value].iloc[index - 1]
+                < data[ColumnController.ma_21.value].iloc[index - 1]
+            )
+            and (
+                data[ColumnController.close.value].iloc[index]
+                > data[ColumnController.ma_50.value].iloc[index]
+            )
+        ):
+            cross_info.last_cross_up = dt_to_str(
+                data[ColumnController.date.value].iloc[index]
+            )
+
+        return cross_info
+
+    @staticmethod
+    def check_cross_down(
+        data: pd.DataFrame,
+        index: int,
+        cross_info: SMACrossInfo,
+    ) -> SMACrossInfo:
+        """
+        Checks to see if a cross down occured by looking at
+        the current date 7 and 21 day SMA and the previous date
+        7 and 21 day SMA.
+
+        **DEPENDENT ON CHECK_CROSS_UP**
+        Because we double check if a cross up occured below the sma_50
+        so it wasn't considered/logged. In that case, the last_cross_up
+        would still be less than last_cross_down. So if that is the case,
+        we also ignore the cross down following the unlogged cross up.
+
+        **NOTE**
+        We expect the dataframe to be in ASCENDING order by date.
+
+        Args:
+            data (pd.DataFrame): Data to parse SMA info.
+            index (int): Indicates current day. index + 1 = prev day.
+            cross_info (SMACrossInfo): Cross info to update.
+
+        Returns:
+            SMACrossInfo: Updated SMACross info object.
+        """
+        if (
+            (
+                data[ColumnController.ma_7.value].iloc[index]
+                < data[ColumnController.ma_21.value].iloc[index]
+            )
+            and (
+                data[ColumnController.ma_7.value].iloc[index - 1]
+                >= data[ColumnController.ma_21.value].iloc[index - 1]
+            )
+            and (
+                # TODO: Should we change this to > ???
+                str_to_dt(cross_info.last_cross_down)
+                < str_to_dt(cross_info.last_cross_up)
+            )
+        ):
+            cross_info.last_cross_down = dt_to_str(
+                data[ColumnController.date.value].iloc[index]
+            )
+
+        return cross_info
 
 
 class SMACross(AbstractStrategy):
@@ -44,63 +138,6 @@ class SMACross(AbstractStrategy):
         except IndexError:
             data = {ColumnController.date.value: None}
         return data
-
-    @staticmethod
-    def cross_up(data: pd.DataFrame, index: int) -> bool:
-        """Checks to see if a cross up occured by looking at
-        the current date 7 and 21 day SMA and the previous date
-        7 and 21 day SMA. Finally, we only consider cross up
-        when the close price > 50 ay SMA otherwise the market
-        is considered bearish.
-
-        **NOTE**
-        We expect the dataframe to be in ASCENDING order by date.
-
-        Args:
-            data (pd.DataFrame): Data to parse SMA info.
-            index (int): Indicates current day. index + 1 = prev day.
-
-        Returns:
-            bool: True if all conditions are met.
-        """
-        return (
-            (
-                data[ColumnController.ma_7.value].iloc[index]
-                >= data[ColumnController.ma_21.value].iloc[index]
-            )
-            and (
-                data[ColumnController.ma_7.value].iloc[index - 1]
-                < data[ColumnController.ma_21.value].iloc[index - 1]
-            )
-            and (
-                data[ColumnController.close.value].iloc[index]
-                > data[ColumnController.ma_50.value].iloc[index]
-            )
-        )
-
-    @staticmethod
-    def cross_down(data: pd.DataFrame, index: int) -> bool:
-        """Checks to see if a cross down occured by looking at
-        the current date 7 and 21 day SMA and the previous date
-        7 and 21 day SMA.
-
-        **NOTE**
-        We expect the dataframe to be in ASCENDING order by date.
-
-        Args:
-            data (pd.DataFrame): Data to parse SMA info.
-            index (int): Indicates current day. index + 1 = prev day.
-
-        Returns:
-            bool: True if all conditions are met.
-        """
-        return (
-            data[ColumnController.ma_7.value].iloc[index]
-            < data[ColumnController.ma_21.value].iloc[index]
-        ) and (
-            data[ColumnController.ma_7.value].iloc[index - 1]
-            >= data[ColumnController.ma_21.value].iloc[index - 1]
-        )
 
     def _update_last_status(self, signal: StockStatusController) -> None:
         """Updates the ast_status value to the given signal for the

--- a/back_testing/sma_cross_backtest.py
+++ b/back_testing/sma_cross_backtest.py
@@ -254,7 +254,6 @@ class SMACrossBackTester:
                     cross_info.last_cross_up = dt_to_str(
                         self.price_data[ColumnController.date.value].iloc[idx]
                     )
-                    fake_kv_repo.set(self.ticker, cross_info.dict())
 
                 elif SMACross.cross_down(self.price_data[: (idx + 1)], idx):
                     # Checks the case when we had a cross up in bear market
@@ -265,7 +264,8 @@ class SMACrossBackTester:
                         cross_info.last_cross_down = dt_to_str(
                             self.price_data[ColumnController.date.value].iloc[idx]
                         )
-                        fake_kv_repo.set(self.ticker, cross_info.dict())
+
+                fake_kv_repo.set(self.ticker, cross_info.dict())
 
                 sma = SMACross(self.ticker, fake_db_repo, fake_kv_repo)
                 result = sma.run()

--- a/back_testing/sma_cross_backtest.py
+++ b/back_testing/sma_cross_backtest.py
@@ -20,8 +20,7 @@ from algo_trading.config.controllers import (
     StockStatusController,
     SMACrossInfo,
 )
-from algo_trading.utils.utils import str_to_dt
-from algo_trading.config.events import TradeEvent
+
 
 LOG, LOG_INFO = get_main_logger(
     log_name="SMA_backtest",

--- a/back_testing/sma_cross_backtest.py
+++ b/back_testing/sma_cross_backtest.py
@@ -307,9 +307,7 @@ class SMACrossBackTester:
             LOG.debug(f"Selling all for a new capital of {self.capital}.")
         percent_change = self._get_percent_change(starting_cap, self.capital)
 
-        LOG.info(f"Successfully backtested SMA Cross for {self.ticker}.\n")
-
-        return BackTestResult(
+        res = BackTestResult(
             ticker=self.ticker,
             start_date=dt_to_str(self.price_data[ColumnController.date.value].iloc[0]),
             end_date=dt_to_str(self.price_data[ColumnController.date.value].iloc[-1]),
@@ -318,6 +316,12 @@ class SMACrossBackTester:
             cap_gains=percent_change,
             num_trades=num_trades,
         )
+
+        LOG.info(
+            f"Successfully backtested SMA Cross for {self.ticker}:\n {json.dumps(res.dict(), indent=2)}\n"
+        )
+
+        return res
 
 
 if __name__ == "__main__":
@@ -333,4 +337,3 @@ if __name__ == "__main__":
         capital=1000,
     )
     result: BackTestResult = tester.test()
-    print(json.dumps(result.dict(), indent=2))

--- a/dags/sma_cross_dag.py
+++ b/dags/sma_cross_dag.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from algo_trading.logger.default_logger import get_main_logger
 from algo_trading.logger.controllers import LogLevelController
-from algo_trading.strategies.sma_cross_strat import SMACross
+from algo_trading.strategies.sma_cross_strat import SMACross, SMACrossUtils
 from algo_trading.repositories.db_repository import DBRepository
 from algo_trading.repositories.key_val_repository import KeyValueRepository
 from algo_trading.repositories.obj_store_repository import ObjStoreRepository
@@ -71,22 +71,18 @@ def backfill_redis(new_tickers: List[str]) -> None:
 
         LOG.info(f"Backfilling cross up/down info for {ticker}")
 
-        cross_info = SMACrossInfo()
+        init_cross_info = SMACrossInfo()
 
         # Dirty way of finding out last cross up and cross down - can def do better
         for i in range(len(data.index) - 1, 1, -1):
-            if SMACross.cross_up(data, i):
-                cross_info.last_cross_up = dt_to_str(
-                    data[ColumnController.date.value].iloc[i]
-                )
+            cross_info = SMACrossUtils.check_cross_up(data, i, init_cross_info)
+            if cross_info.last_cross_up != init_cross_info.last_cross_up:
                 LOG.info(f"Last cross up: {cross_info.last_cross_up}")
                 break
 
         for i in range(len(data.index) - 1, 1, -1):
-            if SMACross.cross_down(data, i):
-                cross_info.last_cross_down = dt_to_str(
-                    data[ColumnController.date.value].iloc[i]
-                )
+            cross_info = SMACrossUtils.check_cross_down(data, i, cross_info)
+            if cross_info.last_cross_down != init_cross_info.last_cross_down:
                 LOG.info(f"Last cross down: {cross_info.last_cross_down}")
                 break
 
@@ -124,19 +120,8 @@ def update_redis(tickers: List, new_tickers: List) -> None:
 
         cross_info = SMACrossInfo(**json.loads(cross_info))
 
-        if SMACross.cross_up(data, 0):
-            cross_info.last_cross_up = dt_to_str(
-                data[ColumnController.date.value].iloc[0]
-            )
-
-        elif SMACross.cross_down(data, 0):
-            # Checks the case when we had a cross up in bear market
-            if str_to_dt(cross_info.last_cross_down) < str_to_dt(
-                cross_info.last_cross_up
-            ):
-                cross_info.last_cross_down = dt_to_str(
-                    data[ColumnController.date.value].iloc[0]
-                )
+        cross_info = SMACrossUtils.check_cross_up(data, 0, cross_info)
+        cross_info = SMACrossUtils.check_cross_down(data, 0, cross_info)
 
         KV_HANDLER.set(ticker, cross_info.dict())
         LOG.info(

--- a/dags/sma_cross_dag.py
+++ b/dags/sma_cross_dag.py
@@ -11,7 +11,6 @@ from algo_trading.repositories.db_repository import DBRepository
 from algo_trading.repositories.key_val_repository import KeyValueRepository
 from algo_trading.repositories.obj_store_repository import ObjStoreRepository
 from algo_trading.config.controllers import (
-    ColumnController,
     StockStatusController,
     ObjStoreController,
     DBHandlerController,

--- a/dags/sma_cross_dag.py
+++ b/dags/sma_cross_dag.py
@@ -2,6 +2,7 @@ import os
 import json
 from typing import List
 from datetime import datetime
+import copy
 
 from algo_trading.logger.default_logger import get_main_logger
 from algo_trading.logger.controllers import LogLevelController
@@ -72,10 +73,11 @@ def backfill_redis(new_tickers: List[str]) -> None:
         LOG.info(f"Backfilling cross up/down info for {ticker}")
 
         init_cross_info = SMACrossInfo()
+        cross_info = copy.deepcopy(init_cross_info)
 
-        # Dirty way of finding out last cross up and cross down - can def do better
+        # TODO: Dirty way of finding out last cross up and cross down - can def do better
         for i in range(len(data.index) - 1, 1, -1):
-            cross_info = SMACrossUtils.check_cross_up(data, i, init_cross_info)
+            cross_info = SMACrossUtils.check_cross_up(data, i, cross_info)
             if cross_info.last_cross_up != init_cross_info.last_cross_up:
                 LOG.info(f"Last cross up: {cross_info.last_cross_up}")
                 break

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,3 +1,23 @@
+#!/usr/bin/env bash
+
+# creates a new terminal window
+# function new() {
+#     if [[ $# -eq 0 ]]; then
+#         open -a "Terminal" "$PWD"
+#     else
+#         open -a "Terminal" "$@"
+#     fi
+# }
+
+# echo "Build from scratch? (y)"
+# read from_scratch
+
+# if [ "$from_scratch" == "y" ]; then
+#     echo "Tearing down and building from scratch..."
+#     ./startup.sh y
+#     sleep 5
+#     new
+# fi
 
 #Orchestrating the DAGs
 cd ./dags


### PR DESCRIPTION
Created `SMACrossUtils` that contains logic for `cross_up` and `cross_down`. 

One thing i want to double check is the logic for the `cross_down` part. Don't we want it to only register the cross down if `up < down` ? because if there was a cross up in the bear market, we wouldn't log it....so then we would have the case that `up < down`. So, if we have a cross down but still have `up < down`, it means a cross up happened but wasn't logged i.e. it was during bear market. `UPDATE` - i'm absolutely trippin - it makes sense now - if the cross up WAS registered, then we would have cross_down < cross_up - and only in that case do we want to register the cross_down.

Another thing, i want to double check visually that our cross info is registering at the right dates. i noticed that both `nio` and `aapl` had cross downs on the same date. maybe it's coincidence, but maybe i effed up the logic in `SMACrossUtils.cross_down()`.

`UPDATE` i backfilled a bunch of other stocks and it seems like the cross_down logic is ok. still would like to double check using your visual graphs.