### PR TITLE
Separated out dependencies

### DIFF
--- a/Dockerfile.notification
+++ b/Dockerfile.notification
@@ -1,7 +1,7 @@
 FROM python:3.8-slim-buster
 
 RUN apt-get update && apt-get -y install gcc
-COPY requirements.txt /
+COPY ./email_service/requirements.txt /
 RUN pip install --upgrade pip && pip install -r /requirements.txt
 
 # Copying algo_trading "package" and adding to PYTHONPATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ black==21.12b0
 boto3==1.20.26
 botocore==1.23.26
 click==8.0.3
-fastapi==0.74.0
 greenlet==1.1.2
 importlib-metadata==4.8.2
 jmespath==0.10.0
@@ -20,13 +19,9 @@ redis==3.5.3
 s3transfer==0.5.0
 six==1.16.0
 SQLAlchemy==1.4.22
-starlette==0.17.1
 tomli==1.2.3
 typed-ast==1.5.1
 typing-extensions==4.0.1
 urllib3==1.26.6
-uvicorn==0.17.5
-uvloop==0.16.0
-watchgod==0.7
-websockets==10.1
+wheel==0.37.1
 zipp==3.6.0


### PR DESCRIPTION
put only dependencies necessary for `email_service` in its `requirements.txt` file so we can make the `algo_trading` requirements.txt as small as possible.