### PR TITLE
added macd_cross_strat.py & updated controllers.py

### DIFF
--- a/algo_trading/config/controllers.py
+++ b/algo_trading/config/controllers.py
@@ -124,3 +124,10 @@ class SMACrossInfo(BaseModel):
     last_cross_up: str = "1900-01-01"
     last_cross_down: str = "1900-01-02"
     last_status: StockStatusController = StockStatusController.sell
+
+
+class MACDCrossInfo(BaseModel):
+
+    last_cross_up: str = "1900-01-01"
+    last_cross_down: str = "1900-01-02"
+    last_status: StockStatusController = StockStatusController.sell

--- a/algo_trading/strategies/macd_cross_strat.py
+++ b/algo_trading/strategies/macd_cross_strat.py
@@ -1,0 +1,178 @@
+from typing import Dict
+import json
+import pandas as pd
+
+from algo_trading.strategies.abstract_strategy import AbstractStrategy
+from algo_trading.config.events import TradeEvent
+from algo_trading.config.controllers import (
+    ColumnController,
+    StockStatusController,
+    MACDCrossInfo,
+)
+from algo_trading.repositories.db_repository import AbstractDBRepository
+from algo_trading.repositories.key_val_repository import AbstractKeyValueRepository
+from algo_trading.utils.utils import dt_to_str, str_to_dt
+
+
+class MACDCrossUtils:
+    @staticmethod
+    def _calc_macd_signal(
+        data: pd.DataFrame,
+        index: int,
+    ) -> tuple:
+        """
+        This function will calculate the MACD line based on the 26EMA - 12EMA and subtract it from the 9EMA to find the
+        convergence/divergence value for both the current and previous day. Signal Line is the 9EMA.
+
+        Args:
+            data (pd.DataFrame): Data to parse EMA info.
+            index (int): Indicates current day. Index - 1 is previous day
+        Returns:
+            tuple: Provides the current day and previous day, respectively, MACD convergence/divergence value (macd_cdv).
+        """
+        # Calculates the MACD signal value of the current day and previous day
+        macd_signal_curr = (
+            data[ColumnController.ema_26].iloc[index]
+            - data[ColumnController.ema_12].iloc[index]
+        )
+        macd_signal_prev = (
+            data[ColumnController.ema_26].iloc[index - 1]
+            - data[ColumnController.ema_12].iloc[index - 1]
+        )
+
+        # Calculates the convergence/divergence value for the current and previous day
+        macd_cdv_curr = macd_signal_curr - data[ColumnController.ema_9].iloc[index]
+        macd_cdv_prev = macd_signal_prev - data[ColumnController.ema_9].iloc[index - 1]
+
+        return macd_cdv_curr, macd_cdv_prev
+
+    @staticmethod
+    def check_cross_up(
+        data: pd.DataFrame,
+        index: int,
+        cross_info: MACDCrossInfo,
+    ) -> MACDCrossInfo:
+        """
+        _summary_
+
+        Args:
+            data (pd.DataFrame): _description_
+            index (int): _description_
+            cross_info (MACDCrossInfo): _description_
+
+        Returns:
+            MACDCrossInfo: _description_
+        """
+
+        macd_cdv_curr, macd_cdv_prev = MACDCrossUtils._calc_macd_signal(data, index)
+
+        # Checks to see if the cdv on the current day is greater than 0 (meaning that MACD line is greater than Signal)
+        if macd_cdv_curr > 0 and macd_cdv_prev <= 0:
+            cross_info.last_cross_up = dt_to_str(
+                data[ColumnController.date.value].iloc[index]
+            )
+
+        return cross_info
+
+    @staticmethod
+    def check_cross_down(
+        data: pd.DataFrame,
+        index: int,
+        cross_info: MACDCrossInfo,
+    ) -> MACDCrossInfo:
+        """
+        _summary_
+
+        Args:
+            data (pd.DataFrame): _description_
+            index (int): _description_
+            cross_info (MACDCrossInfo): _description_
+
+        Returns:
+            MACDCrossInfo: _description_
+        """
+
+        macd_cdv_curr, macd_cdv_prev = MACDCrossUtils._calc_macd_signal(data, index)
+
+        # This Means that the MACD line goes below the Signal Line
+        if macd_cdv_curr < 0 and macd_cdv_prev >= 0:
+            cross_info.last_cross_down = dt_to_str(
+                data[ColumnController.date.value].iloc[index]
+            )
+
+        return cross_info
+
+
+class MACDCross(AbstractStrategy):
+    def __init__(
+        self,
+        ticker: str,
+        macd_db: AbstractDBRepository,
+        cross_db: AbstractKeyValueRepository,
+    ) -> None:
+        self.ticker = ticker
+        self.macd_db = macd_db
+        self.cross_db = cross_db
+
+    @property
+    def cross_info(self) -> MACDCrossInfo:
+        try:
+            return self._cross_info
+        except AttributeError:
+            self._cross_info = MACDCrossInfo(
+                **json.loads(self.cross_db.get(self.ticker))
+            )
+            return self._cross_info
+
+    @property
+    def macd_info(self) -> Dict:
+        data = self.macd_db.get_days_back(self.ticker, 1)
+        try:
+            data = data.to_dict("records")[0]
+        except IndexError:
+            data = {ColumnController.date.value: None}
+        return data
+
+    def _update_last_status(self, signal: StockStatusController) -> None:
+        """Updates the last_status value to the given signal for the
+        Key Value store.
+
+        Args:
+            signal (StockStatusController): Enumeration signal.
+        """
+        current = self.cross_info
+        current.last_status = signal
+        self.cross_db.set(self.ticker, current.dict())
+
+
+def run(self) -> TradeEvent:
+    """Runs the MACDCross strategy logic based on the last cross up/down
+    in the Key Value store.
+
+    Returns:
+        TradeEvent: Event
+    """
+    last_cross_up = str_to_dt(self.cross_info.last_cross_up)
+    last_cross_down = str_to_dt(self.cross_info.last_cross_down)
+    last_status = self.cross_info.last_status
+
+    date = self.macd_info[ColumnController.date.value]
+
+    if date:
+        if last_cross_up > last_cross_down:
+            if last_status == StockStatusController.buy:
+                signal = StockStatusController.hold
+            elif last_status == StockStatusController.sell:
+                signal = StockStatusController.buy
+                self._update_last_status(signal)
+        else:
+            if last_status == StockStatusController.buy:
+                signal = StockStatusController.sell
+                self._update_last_status(signal)
+            elif last_status == StockStatusController.sell:
+                signal = StockStatusController.wait
+
+    else:
+        signal = StockStatusController.wait
+
+    return TradeEvent(date=date, ticker=self.ticker, signal=signal)

--- a/algo_trading/strategies/sma_cross_strat.py
+++ b/algo_trading/strategies/sma_cross_strat.py
@@ -21,7 +21,8 @@ class SMACrossUtils:
         index: int,
         cross_info: SMACrossInfo,
     ) -> SMACrossInfo:
-        """Checks to see if a cross up occured by looking at
+        """
+        Checks to see if a cross up occured by looking at
         the current date 7 and 21 day SMA and the previous date
         7 and 21 day SMA. Finally, we only consider cross up
         when the close price > 50 ay SMA otherwise the market


### PR DESCRIPTION
added the macd_cross_strat.py

- The MACDCrossUtils Class has a similar format to the SMACrossUtils Class but instead calculates the MACD and Signal line instead of having these values stored in the postgres database. The cross up/down functionality is very similar to the sma strategy instead it just strictly looks for + -> - or - -> + changes from the previous to the current day. There is no check like SMA where we had to look at the 50 period SMA and determine if crosses happened above or below the line, we just want to know when cross up or down occurs for MACD.

-The MACDCross Class is pretty much copy paste from what you made for the SMACross Class. I just made sure to update anywhere where it referenced the SMACrossInfo or sma_db. The only issue that I seem to be running into is on lines 155-157. In VSCode, the self.cross_info.last_cross_up or the .last_cross_down do not seem to be changing colors as expected. Is this due to the dags file not being created yet? Anyway, those were the only two things that I noticed as odd when I was working on this.

Let me know if there are any other glaring issues in my .py file.